### PR TITLE
Stick to google docs naming conventions

### DIFF
--- a/app/src/main/kotlin/com/mitch/safevault/MainActivity.kt
+++ b/app/src/main/kotlin/com/mitch/safevault/MainActivity.kt
@@ -127,8 +127,8 @@ private fun shouldUseDarkTheme(
 ): Boolean = when (uiState) {
     MainActivityUiState.Loading -> isSystemInDarkTheme()
     is MainActivityUiState.Success -> when (uiState.theme) {
-        com.mitch.safevault.core.util.SafeVaultTheme.DARK -> true
-        com.mitch.safevault.core.util.SafeVaultTheme.LIGHT -> false
-        com.mitch.safevault.core.util.SafeVaultTheme.FOLLOW_SYSTEM -> isSystemInDarkTheme()
+        com.mitch.safevault.core.util.SafeVaultTheme.Dark -> true
+        com.mitch.safevault.core.util.SafeVaultTheme.Light -> false
+        com.mitch.safevault.core.util.SafeVaultTheme.FollowSystem -> isSystemInDarkTheme()
     }
 }

--- a/app/src/main/kotlin/com/mitch/safevault/navigation/SafeVaultNavHost.kt
+++ b/app/src/main/kotlin/com/mitch/safevault/navigation/SafeVaultNavHost.kt
@@ -9,15 +9,15 @@ import com.mitch.safevault.feature.auth.navigation.navigateToSignUp
 import com.mitch.safevault.feature.auth.navigation.signUpScreen
 import com.mitch.safevault.feature.items.navigation.itemsScreen
 import com.mitch.safevault.feature.masterpassword.navigation.masterPasswordScreen
+import com.mitch.safevault.feature.onboarding.navigation.OnboardingGraphRoutePattern
 import com.mitch.safevault.feature.onboarding.navigation.onboardingGraph
-import com.mitch.safevault.feature.onboarding.navigation.onboardingGraphRoute
 import com.mitch.safevault.ui.SafeVaultAppState
 
 @Composable
 fun SafeVaultNavHost(
     appState: SafeVaultAppState,
     modifier: Modifier = Modifier,
-    startDestination: String = onboardingGraphRoute
+    startDestination: String = OnboardingGraphRoutePattern
 ) {
     val navController = appState.navController
     NavHost(

--- a/app/src/main/kotlin/com/mitch/safevault/ui/util/ToastController.kt
+++ b/app/src/main/kotlin/com/mitch/safevault/ui/util/ToastController.kt
@@ -9,7 +9,7 @@ object ToastController {
     fun show(
         context: Context,
         message: String,
-        duration: ToastDuration = ToastDuration.SHORT
+        duration: ToastDuration = ToastDuration.Short
     ) {
         if (showingToast != null) {
             showingToast?.cancel()
@@ -18,8 +18,8 @@ object ToastController {
             context,
             message,
             when (duration) {
-                ToastDuration.SHORT -> Toast.LENGTH_SHORT
-                ToastDuration.LONG -> Toast.LENGTH_LONG
+                ToastDuration.Short -> Toast.LENGTH_SHORT
+                ToastDuration.Long -> Toast.LENGTH_LONG
             }
         )
         showingToast?.show()
@@ -27,6 +27,6 @@ object ToastController {
 }
 
 enum class ToastDuration {
-    SHORT,
-    LONG
+    Short,
+    Long
 }

--- a/core/data/src/main/kotlin/com/mitch/safevault/core/data/mapper/ProtoMapper.kt
+++ b/core/data/src/main/kotlin/com/mitch/safevault/core/data/mapper/ProtoMapper.kt
@@ -4,13 +4,13 @@ import com.mitch.safevault.core.datastore.ProtoUserPreferences.ProtoAppTheme
 import com.mitch.safevault.core.util.SafeVaultTheme
 
 fun SafeVaultTheme.toDataModel(): ProtoAppTheme = when (this) {
-    SafeVaultTheme.FOLLOW_SYSTEM -> ProtoAppTheme.FOLLOW_SYSTEM
-    SafeVaultTheme.LIGHT -> ProtoAppTheme.LIGHT
-    SafeVaultTheme.DARK -> ProtoAppTheme.DARK
+    SafeVaultTheme.FollowSystem -> ProtoAppTheme.FOLLOW_SYSTEM
+    SafeVaultTheme.Light -> ProtoAppTheme.LIGHT
+    SafeVaultTheme.Dark -> ProtoAppTheme.DARK
 }
 
 fun ProtoAppTheme.toDomainModel(): SafeVaultTheme = when (this) {
-    ProtoAppTheme.LIGHT -> SafeVaultTheme.LIGHT
-    ProtoAppTheme.DARK -> SafeVaultTheme.DARK
-    ProtoAppTheme.UNRECOGNIZED, ProtoAppTheme.FOLLOW_SYSTEM -> SafeVaultTheme.FOLLOW_SYSTEM
+    ProtoAppTheme.LIGHT -> SafeVaultTheme.Light
+    ProtoAppTheme.DARK -> SafeVaultTheme.Dark
+    ProtoAppTheme.UNRECOGNIZED, ProtoAppTheme.FOLLOW_SYSTEM -> SafeVaultTheme.FollowSystem
 }

--- a/core/designsystem/src/main/kotlin/com/mitch/safevault/core/designsystem/SafeVaultIcons.kt
+++ b/core/designsystem/src/main/kotlin/com/mitch/safevault/core/designsystem/SafeVaultIcons.kt
@@ -3,8 +3,6 @@ package com.mitch.safevault.core.designsystem
 import compose.icons.EvaIcons
 import compose.icons.evaicons.Outline
 import compose.icons.evaicons.outline.ArrowForward
-import compose.icons.evaicons.outline.ArrowRight
-import compose.icons.evaicons.outline.Close
 
 object SafeVaultIcons {
     val ArrowRight = EvaIcons.Outline.ArrowForward

--- a/core/util/src/main/kotlin/com/mitch/safevault/core/util/SafeVaultLanguage.kt
+++ b/core/util/src/main/kotlin/com/mitch/safevault/core/util/SafeVaultLanguage.kt
@@ -7,16 +7,16 @@ enum class SafeVaultLanguage(
     val locale: Locale,
     @DrawableRes val flagId: Int
 ) {
-    ENGLISH(locale = Locale.ENGLISH, flagId = R.drawable.english_flag),
-    ITALIAN(locale = Locale.ITALIAN, flagId = R.drawable.italian_flag);
+    English(locale = Locale.ENGLISH, flagId = R.drawable.english_flag),
+    Italian(locale = Locale.ITALIAN, flagId = R.drawable.italian_flag);
 
     companion object {
         fun fromLocale(locale: Locale): SafeVaultLanguage {
             return values().find { it.locale == locale } ?: default()
         }
 
-        fun default(): SafeVaultLanguage {
-            return ENGLISH
+        private fun default(): SafeVaultLanguage {
+            return English
         }
     }
 }

--- a/core/util/src/main/kotlin/com/mitch/safevault/core/util/SafeVaultTheme.kt
+++ b/core/util/src/main/kotlin/com/mitch/safevault/core/util/SafeVaultTheme.kt
@@ -5,13 +5,13 @@ import androidx.annotation.StringRes
 enum class SafeVaultTheme(
     @StringRes val translationId: Int
 ) {
-    FOLLOW_SYSTEM(R.string.system_default),
-    LIGHT(R.string.light_theme),
-    DARK(R.string.dark_theme);
+    FollowSystem(R.string.system_default),
+    Light(R.string.light_theme),
+    Dark(R.string.dark_theme);
 
     companion object {
         fun default(): SafeVaultTheme {
-            return FOLLOW_SYSTEM
+            return FollowSystem
         }
     }
 }

--- a/feature/onboarding/src/main/kotlin/com/mitch/safevault/feature/onboarding/navigation/OnboardingNavigation.kt
+++ b/feature/onboarding/src/main/kotlin/com/mitch/safevault/feature/onboarding/navigation/OnboardingNavigation.kt
@@ -7,11 +7,11 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import com.mitch.safevault.feature.onboarding.OnboardingRoute
 
-const val onboardingGraphRoute = "onboarding_graph"
-private const val ONBOARDING_NAVIGATION_ROUTE = "onboarding"
+const val OnboardingGraphRoutePattern = "onboarding_graph"
+private const val OnboardingNavigationRoute = "onboarding"
 
 fun NavController.navigateToOnboardingGraph(navOptions: NavOptions? = null) {
-    this.navigate(onboardingGraphRoute, navOptions)
+    this.navigate(OnboardingGraphRoutePattern, navOptions)
 }
 
 fun NavGraphBuilder.onboardingGraph(
@@ -20,10 +20,10 @@ fun NavGraphBuilder.onboardingGraph(
     nestedGraphs: NavGraphBuilder.() -> Unit
 ) {
     navigation(
-        startDestination = ONBOARDING_NAVIGATION_ROUTE,
-        route = onboardingGraphRoute
+        startDestination = OnboardingNavigationRoute,
+        route = OnboardingGraphRoutePattern
     ) {
-        composable(route = ONBOARDING_NAVIGATION_ROUTE) {
+        composable(route = OnboardingNavigationRoute) {
             OnboardingRoute(
                 onNavigateToSignup = onNavigateToSignup,
                 onNavigateToLogin = onNavigateToLogin


### PR DESCRIPTION
Described [here](https://github.com/androidx/androidx/blob/androidx-main/compose/docs/compose-api-guidelines.md)

Change:
- enum classes values from CAPITALS_AND_UNDERSCORES to PascalCase
- const val to PascalCase (even if private)