### PR TITLE
Use correct semantics in text fields

### DIFF
--- a/core/domain/src/main/kotlin/com/mitch/safevault/core/domain/usecase/LogInUseCase.kt
+++ b/core/domain/src/main/kotlin/com/mitch/safevault/core/domain/usecase/LogInUseCase.kt
@@ -40,7 +40,9 @@ class LogInUseCase @Inject constructor(
             && PasswordError.EmptyField in passwordValidationResult.reasons
         ) {
             PasswordError.EmptyField
-        } else null
+        } else {
+            null
+        }
     }
 
     private fun hasValidationErrors(

--- a/core/ui/src/main/kotlin/com/mitch/safevault/core/ui/component/email/EmailTextField.kt
+++ b/core/ui/src/main/kotlin/com/mitch/safevault/core/ui/component/email/EmailTextField.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.error
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import com.mitch.safevault.core.util.validator.email.EmailError

--- a/core/ui/src/main/kotlin/com/mitch/safevault/core/ui/component/password/PasswordTextField.kt
+++ b/core/ui/src/main/kotlin/com/mitch/safevault/core/ui/component/password/PasswordTextField.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.error
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation

--- a/feature/auth/src/main/kotlin/com/mitch/safevault/feature/auth/login/LogInScreen.kt
+++ b/feature/auth/src/main/kotlin/com/mitch/safevault/feature/auth/login/LogInScreen.kt
@@ -3,34 +3,14 @@ package com.mitch.safevault.feature.auth.login
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.mitch.safevault.core.designsystem.SafeVaultIcons
-import com.mitch.safevault.core.ui.component.email.EmailTextField
 import com.mitch.safevault.core.ui.component.email.EmailState
+import com.mitch.safevault.core.ui.component.email.EmailTextField
 import com.mitch.safevault.core.ui.component.password.PasswordState
 import com.mitch.safevault.core.ui.component.password.PasswordTextField
-import com.mitch.safevault.core.util.validator.email.EmailError
-import com.mitch.safevault.core.util.validator.password.PasswordError
 
 @Composable
 internal fun LogInRoute(


### PR DESCRIPTION
Add import `import androidx.compose.ui.semantics.error`, so that it doesn't conflict with Kotlin `error` function