### PR TITLE
Login

### DIFF
--- a/core/data/src/main/kotlin/com/mitch/safevault/core/data/remote/DefaultAuthApi.kt
+++ b/core/data/src/main/kotlin/com/mitch/safevault/core/data/remote/DefaultAuthApi.kt
@@ -3,7 +3,6 @@ package com.mitch.safevault.core.data.remote
 import com.mitch.safevault.core.data.remote.request.CreateAccountRequest
 import com.mitch.safevault.core.data.remote.request.LogInRequest
 import com.mitch.safevault.core.util.validator.email.EmailAuthError
-import com.mitch.safevault.core.util.validator.email.EmailError
 import com.mitch.safevault.core.util.validator.password.PasswordAuthError
 import javax.inject.Inject
 
@@ -13,7 +12,7 @@ class DefaultAuthApi @Inject constructor() : AuthApi {
     }
 
     override suspend fun logIn(request: LogInRequest): AuthApiResponse {
-        return AuthApiResponse.Error(emailError = EmailError.NoExistingAccount)
+        return AuthApiResponse.Error(emailError = EmailAuthError.NoExistingAccount)
     }
 }
 

--- a/core/designsystem/src/main/kotlin/com/mitch/safevault/core/designsystem/SafeVaultIcons.kt
+++ b/core/designsystem/src/main/kotlin/com/mitch/safevault/core/designsystem/SafeVaultIcons.kt
@@ -2,6 +2,7 @@ package com.mitch.safevault.core.designsystem
 
 import compose.icons.EvaIcons
 import compose.icons.evaicons.Outline
+import compose.icons.evaicons.outline.AlertCircle
 import compose.icons.evaicons.outline.ArrowForward
 import compose.icons.evaicons.outline.Eye
 import compose.icons.evaicons.outline.EyeOff
@@ -10,4 +11,5 @@ object SafeVaultIcons {
     val ArrowRight = EvaIcons.Outline.ArrowForward
     val Eye = EvaIcons.Outline.Eye
     val EyeOff = EvaIcons.Outline.EyeOff
+    val Error = EvaIcons.Outline.AlertCircle
 }

--- a/core/domain/src/main/kotlin/com/mitch/safevault/core/domain/usecase/LogInUseCase.kt
+++ b/core/domain/src/main/kotlin/com/mitch/safevault/core/domain/usecase/LogInUseCase.kt
@@ -6,7 +6,7 @@ import com.mitch.safevault.core.util.validator.email.EmailValidationError
 import com.mitch.safevault.core.util.validator.email.EmailValidationResult
 import com.mitch.safevault.core.util.validator.email.EmailValidator
 import com.mitch.safevault.core.util.validator.password.PasswordAuthError
-import com.mitch.safevault.core.util.validator.password.PasswordError
+import com.mitch.safevault.core.util.validator.password.PasswordValidationError
 import com.mitch.safevault.core.util.validator.password.PasswordValidationResult
 import com.mitch.safevault.core.util.validator.password.PasswordValidator
 import javax.inject.Inject
@@ -28,13 +28,13 @@ class LogInUseCase @Inject constructor(
         }
     }
 
-    fun validatePassword(password: String): PasswordError.EmptyField? {
+    fun validatePassword(password: String): PasswordValidationError.EmptyField? {
         val passwordValidationResult = passwordValidator.validate(password.trim())
         return if (
             passwordValidationResult is PasswordValidationResult.InvalidPassword
-            && PasswordError.EmptyField in passwordValidationResult.reasons
+            && PasswordValidationError.EmptyField in passwordValidationResult.reasons
         ) {
-            PasswordError.EmptyField
+            PasswordValidationError.EmptyField
         } else {
             null
         }

--- a/core/ui/src/main/kotlin/com/mitch/safevault/core/ui/component/email/EmailTextField.kt
+++ b/core/ui/src/main/kotlin/com/mitch/safevault/core/ui/component/email/EmailTextField.kt
@@ -13,8 +13,6 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import com.mitch.safevault.core.ui.R
-import com.mitch.safevault.core.util.validator.email.EmailAuthError
-import com.mitch.safevault.core.util.validator.email.EmailError
 import com.mitch.safevault.core.util.validator.email.EmailValidationError
 
 @Composable
@@ -57,7 +55,7 @@ fun EmailTextField(
 @Composable
 private fun EmailValidationError.toErrorMessage(): String {
     return when (this) {
-        EmailError.EmptyField -> stringResource(id = R.string.email_error_empty_field)
-        EmailError.NotAnEmail -> stringResource(id = R.string.email_error_not_valid)
+        EmailValidationError.EmptyField -> stringResource(id = R.string.email_error_empty_field)
+        EmailValidationError.NotAnEmail -> stringResource(id = R.string.email_error_not_valid)
     }
 }

--- a/core/ui/src/main/kotlin/com/mitch/safevault/core/ui/component/password/PasswordTextField.kt
+++ b/core/ui/src/main/kotlin/com/mitch/safevault/core/ui/component/password/PasswordTextField.kt
@@ -34,7 +34,7 @@ fun PasswordTextField(
         onValueChange = { passwordState.password = it },
         modifier = modifier
             .semantics {
-                 password()
+                password()
                 if (passwordState.validationError != null) error(passwordErrorMessage)
             }
             .fillMaxWidth(),
@@ -46,10 +46,10 @@ fun PasswordTextField(
                     if (passwordState.isPasswordVisible) SafeVaultIcons.EyeOff else SafeVaultIcons.Eye
                 // Please provide localized description for accessibility services
                 val description = if (passwordState.isPasswordVisible) {
-                        stringResource(id = R.string.hide_password)
-                    } else {
+                    stringResource(id = R.string.hide_password)
+                } else {
                     stringResource(id = R.string.show_password)
-                    }
+                }
                 Icon(imageVector = visibilityIcon, contentDescription = description)
             }
         },

--- a/core/util/src/main/kotlin/com/mitch/safevault/core/util/validator/email/EmailError.kt
+++ b/core/util/src/main/kotlin/com/mitch/safevault/core/util/validator/email/EmailError.kt
@@ -1,11 +1,12 @@
 package com.mitch.safevault.core.util.validator.email
 
-sealed interface EmailAuthError
-sealed interface EmailValidationError
-
-sealed interface EmailError {
-    data object EmptyField : EmailValidationError
-    data object NotAnEmail : EmailValidationError
+sealed interface EmailAuthError : EmailError {
     data object NoExistingAccount : EmailAuthError
     data object AlreadyExistingAccount : EmailAuthError
 }
+sealed interface EmailValidationError : EmailError {
+    data object EmptyField : EmailValidationError
+    data object NotAnEmail : EmailValidationError
+}
+
+sealed interface EmailError

--- a/core/util/src/main/kotlin/com/mitch/safevault/core/util/validator/email/EmailValidator.kt
+++ b/core/util/src/main/kotlin/com/mitch/safevault/core/util/validator/email/EmailValidator.kt
@@ -8,8 +8,8 @@ class Rfc5322EmailValidator : EmailValidator() {
 
     override fun validate(toValidate: String): EmailValidationResult {
         return when {
-            toValidate.isBlank() -> EmailValidationResult.InvalidEmail(EmailError.EmptyField)
-            !emailMatcher.matches(toValidate) -> EmailValidationResult.InvalidEmail(EmailError.NotAnEmail)
+            toValidate.isBlank() -> EmailValidationResult.InvalidEmail(EmailValidationError.EmptyField)
+            !emailMatcher.matches(toValidate) -> EmailValidationResult.InvalidEmail(EmailValidationError.NotAnEmail)
             else -> EmailValidationResult.Success
         }
     }

--- a/core/util/src/main/kotlin/com/mitch/safevault/core/util/validator/password/PasswordError.kt
+++ b/core/util/src/main/kotlin/com/mitch/safevault/core/util/validator/password/PasswordError.kt
@@ -1,14 +1,15 @@
 package com.mitch.safevault.core.util.validator.password
 
-sealed interface PasswordValidationError
-sealed interface PasswordAuthError
-
-sealed interface PasswordError {
+sealed interface PasswordValidationError : PasswordError {
     data object EmptyField : PasswordValidationError
     data object InputTooShort : PasswordValidationError
     data object NoLowercaseLetter : PasswordValidationError
     data object NoUppercaseLetter : PasswordValidationError
     data object NoNumber : PasswordValidationError
     data object NoSpecialCharacter : PasswordValidationError
+}
+sealed interface PasswordAuthError : PasswordError {
     data object WrongPassword : PasswordAuthError
 }
+
+sealed interface PasswordError

--- a/core/util/src/main/kotlin/com/mitch/safevault/core/util/validator/password/PasswordValidator.kt
+++ b/core/util/src/main/kotlin/com/mitch/safevault/core/util/validator/password/PasswordValidator.kt
@@ -6,12 +6,12 @@ class PasswordValidator : Validator<String, PasswordValidationResult> {
 
     override fun validate(toValidate: String): PasswordValidationResult {
         val errors = listOf(
-            toValidate.isBlank() to PasswordError.EmptyField,
-            (toValidate.length < PasswordConstraints.MIN_LENGTH) to PasswordError.InputTooShort,
-            toValidate.none { it.isLowerCase() } to PasswordError.NoLowercaseLetter,
-            toValidate.none { it.isUpperCase() } to PasswordError.NoUppercaseLetter,
-            toValidate.none { it.isDigit() } to PasswordError.NoNumber,
-            toValidate.none { it in PasswordConstraints.SPECIAL_CHARACTERS } to PasswordError.NoSpecialCharacter
+            toValidate.isBlank() to PasswordValidationError.EmptyField,
+            (toValidate.length < PasswordConstraints.MIN_LENGTH) to PasswordValidationError.InputTooShort,
+            toValidate.none { it.isLowerCase() } to PasswordValidationError.NoLowercaseLetter,
+            toValidate.none { it.isUpperCase() } to PasswordValidationError.NoUppercaseLetter,
+            toValidate.none { it.isDigit() } to PasswordValidationError.NoNumber,
+            toValidate.none { it in PasswordConstraints.SPECIAL_CHARACTERS } to PasswordValidationError.NoSpecialCharacter
         )
             .filter { it.first }
             .map { it.second }

--- a/core/util/src/test/kotlin/com/mitch/safevault/core/util/validator/email/EmailValidatorTest.kt
+++ b/core/util/src/test/kotlin/com/mitch/safevault/core/util/validator/email/EmailValidatorTest.kt
@@ -14,15 +14,15 @@ internal class EmailValidatorTest {
         val emptyEmail = validator.validate("") as EmailValidationResult.InvalidEmail
         val whitespacesOnlyEmail = validator.validate("  ") as EmailValidationResult.InvalidEmail
 
-        assertThat(emptyEmail.reason).isEqualTo(EmailError.EmptyField)
-        assertThat(whitespacesOnlyEmail.reason).isEqualTo(EmailError.EmptyField)
+        assertThat(emptyEmail.reason).isEqualTo(EmailValidationError.EmptyField)
+        assertThat(whitespacesOnlyEmail.reason).isEqualTo(EmailValidationError.EmptyField)
     }
 
     @Test
     fun `when email does not match regex, validator returns no match error`() {
         val result = validator.validate("andrea.com") as EmailValidationResult.InvalidEmail
 
-        assertThat(result.reason).isEqualTo(EmailError.NotAnEmail)
+        assertThat(result.reason).isEqualTo(EmailValidationError.NotAnEmail)
     }
 
     @Test

--- a/core/util/src/test/kotlin/com/mitch/safevault/core/util/validator/password/PasswordValidatorTest.kt
+++ b/core/util/src/test/kotlin/com/mitch/safevault/core/util/validator/password/PasswordValidatorTest.kt
@@ -14,43 +14,43 @@ internal class PasswordValidatorTest {
         val emptyPassword = validator.validate("") as PasswordValidationResult.InvalidPassword
         val whitespacesOnlyPassword = validator.validate("   ") as PasswordValidationResult.InvalidPassword
 
-        assertThat(emptyPassword.reasons).contains(PasswordError.EmptyField)
-        assertThat(whitespacesOnlyPassword.reasons).contains(PasswordError.EmptyField)
+        assertThat(emptyPassword.reasons).contains(PasswordValidationError.EmptyField)
+        assertThat(whitespacesOnlyPassword.reasons).contains(PasswordValidationError.EmptyField)
     }
 
     @Test
     fun `when short password, validator returns too short error`() {
         val result = validator.validate("1234567") as PasswordValidationResult.InvalidPassword
 
-        assertThat(result.reasons).contains(PasswordError.InputTooShort)
+        assertThat(result.reasons).contains(PasswordValidationError.InputTooShort)
     }
 
     @Test
     fun `when only uppercase letters in password, validator returns no lowercase letters error`() {
         val result = validator.validate("PASSWORD") as PasswordValidationResult.InvalidPassword
 
-        assertThat(result.reasons).contains(PasswordError.NoLowercaseLetter)
+        assertThat(result.reasons).contains(PasswordValidationError.NoLowercaseLetter)
     }
 
     @Test
     fun `when only lowercase letters in password, validator returns no uppercase letters error`() {
         val result = validator.validate("password") as PasswordValidationResult.InvalidPassword
 
-        assertThat(result.reasons).contains(PasswordError.NoUppercaseLetter)
+        assertThat(result.reasons).contains(PasswordValidationError.NoUppercaseLetter)
     }
 
     @Test
     fun `when only letters in password, validator returns no number error`() {
         val result = validator.validate("password") as PasswordValidationResult.InvalidPassword
 
-        assertThat(result.reasons).contains(PasswordError.NoNumber)
+        assertThat(result.reasons).contains(PasswordValidationError.NoNumber)
     }
 
     @Test
     fun `when no special characters in password, validator returns no special characters error`() {
         val result = validator.validate("password") as PasswordValidationResult.InvalidPassword
 
-        assertThat(result.reasons).contains(PasswordError.NoSpecialCharacter)
+        assertThat(result.reasons).contains(PasswordValidationError.NoSpecialCharacter)
     }
 
     @Test

--- a/feature/auth/src/main/kotlin/com/mitch/safevault/feature/auth/login/LogInScreen.kt
+++ b/feature/auth/src/main/kotlin/com/mitch/safevault/feature/auth/login/LogInScreen.kt
@@ -2,12 +2,18 @@ package com.mitch.safevault.feature.auth.login
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -25,13 +31,14 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mitch.safevault.core.designsystem.SafeVaultIcons
 import com.mitch.safevault.core.designsystem.theme.SafeVaultMaterialTheme
 import com.mitch.safevault.core.designsystem.theme.padding
 import com.mitch.safevault.core.ui.component.email.EmailState
 import com.mitch.safevault.core.ui.component.email.EmailTextField
 import com.mitch.safevault.core.ui.component.password.PasswordState
 import com.mitch.safevault.core.ui.component.password.PasswordTextField
-import com.mitch.safevault.core.util.validator.email.EmailAuthError
+import com.mitch.safevault.core.ui.extensions.m3.contentPadding
 import com.mitch.safevault.core.util.validator.email.EmailError
 import com.mitch.safevault.core.util.validator.password.PasswordError
 import com.mitch.safevault.feature.auth.R
@@ -79,7 +86,24 @@ internal fun LogInScreen(
     ) {
         if (logInUiState is LogInUiState.AuthenticationFailed) {
             if (logInUiState.emailAuthError != null) {
-                Text(text = stringResource(id = R.string.no_existing_account))
+                Card(
+                    modifier = Modifier.size(width = 250.dp, height = 100.dp),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.errorContainer,
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer
+                    )
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(CardDefaults.contentPadding),
+                        horizontalArrangement = Arrangement.spacedBy(padding.medium),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(imageVector = SafeVaultIcons.Error, contentDescription = null)
+                        Text(text = stringResource(id = R.string.no_existing_account))
+                    }
+                }
             }
 
             if (logInUiState.passwordAuthError != null) {

--- a/feature/auth/src/main/kotlin/com/mitch/safevault/feature/auth/login/LogInScreen.kt
+++ b/feature/auth/src/main/kotlin/com/mitch/safevault/feature/auth/login/LogInScreen.kt
@@ -39,8 +39,10 @@ import com.mitch.safevault.core.ui.component.email.EmailTextField
 import com.mitch.safevault.core.ui.component.password.PasswordState
 import com.mitch.safevault.core.ui.component.password.PasswordTextField
 import com.mitch.safevault.core.ui.extensions.m3.contentPadding
-import com.mitch.safevault.core.util.validator.email.EmailError
-import com.mitch.safevault.core.util.validator.password.PasswordError
+import com.mitch.safevault.core.util.validator.email.EmailAuthError
+import com.mitch.safevault.core.util.validator.email.EmailValidationError
+import com.mitch.safevault.core.util.validator.password.PasswordAuthError
+import com.mitch.safevault.core.util.validator.password.PasswordValidationError
 import com.mitch.safevault.feature.auth.R
 import kotlinx.coroutines.delay
 import com.mitch.safevault.core.util.R as utilR
@@ -85,7 +87,7 @@ internal fun LogInScreen(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         if (logInUiState is LogInUiState.AuthenticationFailed) {
-            if (logInUiState.emailAuthError != null) {
+            if (logInUiState.emailAuthError is EmailAuthError.NoExistingAccount) {
                 Card(
                     modifier = Modifier.size(width = 250.dp, height = 100.dp),
                     colors = CardDefaults.cardColors(
@@ -165,12 +167,12 @@ private fun LogInScreenIdlePreview() {
 @Composable
 private fun LogInScreenValidationErrorsPreview() {
     val emailState = EmailState(
-        onValidateEmail = { _ -> EmailError.EmptyField },
+        onValidateEmail = { _ -> EmailValidationError.EmptyField },
         shouldValidateImmediately = true
     )
 
     val passwordState = PasswordState(
-        onValidatePassword = { _ -> PasswordError.EmptyField },
+        onValidatePassword = { _ -> PasswordValidationError.EmptyField },
         shouldValidateImmediately = true
     )
 
@@ -209,8 +211,8 @@ private fun LogInScreenAuthErrorPreview() {
     SafeVaultMaterialTheme {
         LogInScreen(
             logInUiState = LogInUiState.AuthenticationFailed(
-                emailAuthError = EmailError.NoExistingAccount,
-                passwordAuthError = PasswordError.WrongPassword
+                emailAuthError = EmailAuthError.NoExistingAccount,
+                passwordAuthError = PasswordAuthError.WrongPassword
             ),
             emailState = EmailState(onValidateEmail = { _ -> null }),
             passwordState = PasswordState(onValidatePassword = { _ -> null }),


### PR DESCRIPTION
- Create d"no existing account" UI error
- Made it easier to use `EmailError` and `PasswordError`
  - e.g. before `EmailError.EmptyField`, after `EmailValidationError.EmptyField`
  - but in the end, `EmailValidationError` and `EmailAuthError` are both `EmailError`